### PR TITLE
g3p-9970: Adding pop_back to priority_queue

### DIFF
--- a/include/etl/priority_queue.h
+++ b/include/etl/priority_queue.h
@@ -306,16 +306,28 @@ namespace etl
     }
 
     //*************************************************************************
-    /// Removes the oldest value from the back of the priority queue.
+    /// Removes the highest priority value from the top of the priority queue.
     /// Does nothing if the priority queue is already empty.
     //*************************************************************************
     void pop()
     {
-      // Move largest element to end
+      // Move largest (highest priority) element to end
       etl::pop_heap(container.begin(), container.end(), compare);
       // Actually remove largest element at end
       container.pop_back();
     }
+
+    /* ****************************** SpanIO ****************************** */
+    //*************************************************************************
+    /// Removes the lowest priority value from the back of the priority queue.
+    /// Does nothing if the priority queue is already empty.
+    //*************************************************************************
+    void pop_back()
+    {
+      // Remove largest (lowest-priority) element at end
+      container.pop_back();
+    }
+    /* ****************************** SpanIO ****************************** */
 
     //*************************************************************************
     /// Gets the highest priority value in the priority queue


### PR DESCRIPTION
This allows for consuming code to be able to drop the lowest priority element from the queue, ie. the last element of the container which is maintained internally as sorted.