### PR TITLE
g3p-11671: etl: Add bottom() to priority_queue

### DIFF
--- a/include/etl/priority_queue.h
+++ b/include/etl/priority_queue.h
@@ -145,6 +145,26 @@ namespace etl
       return container.front();
     }
 
+    /* ****************************** SpanIO ****************************** */
+    //*************************************************************************
+    /// Gets a reference to the lowest priority value in the priority queue.<br>
+    /// \return A reference to the lowest priority value in the priority queue.
+    //*************************************************************************
+    reference bottom()
+    {
+      return container.back();
+    }
+
+    //*************************************************************************
+    /// Gets a const reference to the lowest priority value in the priority queue.<br>
+    /// \return A const reference to the lowest priority value in the priority queue.
+    //*************************************************************************
+    const_reference bottom() const
+    {
+      return container.back();
+    }
+    /* ****************************** SpanIO ****************************** */
+
     //*************************************************************************
     /// Adds a value to the queue.
     /// If asserts or exceptions are enabled, throws an etl::priority_queue_full


### PR DESCRIPTION
These are complimentary functions to `top()` that return the lowest priority value in the priority queue.